### PR TITLE
Standardise error codes

### DIFF
--- a/sockets.tcp.js
+++ b/sockets.tcp.js
@@ -16,7 +16,7 @@ var exec = cordova.require('cordova/exec'),
 	    STANDARDISED: 2
 	  }
 	},
-    OS = platform.id == 'android' ? ANDROID : IOS;
+    OS = platform.id == 'android' ? 'ANDROID' : 'IOS';
 
 exports.create = function(properties, callback) {
     if (typeof properties == 'function') {

--- a/sockets.tcp.js
+++ b/sockets.tcp.js
@@ -217,7 +217,7 @@ function registerReceiveEvents() {
 	}
 	
     var fail = function(info) {
-		info.resultCode = standardizeErrorCode(info.resultCode)
+		info.resultCode = standardiseErrorCode(info.resultCode)
 		
         exports.onReceiveError.fire(info);
     };

--- a/sockets.tcp.js
+++ b/sockets.tcp.js
@@ -209,8 +209,7 @@ function registerReceiveEvents() {
     }
 
     function standardiseErrorCode(errorCode) {
-        var standardErrorCode,
-            matchedError = Object.keys(ERROR_CODES).find(function (type) {
+        var matchedError = Object.keys(ERROR_CODES).find(function (type) {
                 return ERROR_CODES[type][OS] === errorCode;
             });
 

--- a/sockets.tcp.js
+++ b/sockets.tcp.js
@@ -213,7 +213,7 @@ function registerReceiveEvents() {
                 return ERROR_CODES[type][OS] === errorCode;
             });
 
-        return ERROR_CODES[matchedError].STANDARDISED;
+        return matchedError ? ERROR_CODES[matchedError].STANDARDISED : errorCode;
     }
 
     var fail = function (info) {

--- a/sockets.tcp.js
+++ b/sockets.tcp.js
@@ -12,7 +12,11 @@ var exec = cordova.require('cordova/exec'),
         	SOCKET_CLOSED_BY_SERVER: 7,
         	CONNECTION_TIMED_OUT: 57
     },
-    HANDLED_ERROR_CODES = platform.id == 'android' ? ANDROID_SOCKET_ERROR_CODES : IOS_SOCKET_ERROR_CODES;
+ 	STANDARDISED_ERROR_CODES = {
+        	SOCKET_CLOSED_BY_SERVER: 1,
+        	CONNECTION_TIMED_OUT: 2
+    },
+    NATIVE_ERROR_CODES = platform.id == 'android' ? ANDROID_SOCKET_ERROR_CODES : IOS_SOCKET_ERROR_CODES;
 
 exports.create = function(properties, callback) {
     if (typeof properties == 'function') {
@@ -204,8 +208,17 @@ function registerReceiveEvents() {
         })();
     }
 
+	function standardiseErrorCode(errorCode) {
+		var errorType = Object.keys(NATIVE_ERROR_CODES).find(function (type) {
+			return (NATIVE_ERROR_CODES[type] === info.resultCode);
+		});
+		
+		return STANDARDISED_ERROR_CODES[errorType];
+	}
+	
     var fail = function(info) {
-	debugger
+		info.resultCode = standardizeErrorCode(info.resultCode)
+		
         exports.onReceiveError.fire(info);
     };
 

--- a/sockets.tcp.js
+++ b/sockets.tcp.js
@@ -4,18 +4,18 @@
 var Event = require('cordova-plugin-chrome-apps-common.events');
 var platform = cordova.require('cordova/platform');
 var exec = cordova.require('cordova/exec'),
-	ERROR_CODES = {
-	  SOCKET_CLOSED_BY_SERVER: {
-	    ANDROID: -100,
-	    IOS: 7,
-	    STANDARDISED: 1
-	  },
-	  CONNECTION_TIMED_OUT: {
-	    ANDROID: -118,
-	    IOS: 57,
-	    STANDARDISED: 2
-	  }
-	},
+    ERROR_CODES = {
+        SOCKET_CLOSED_BY_SERVER: {
+            ANDROID: -100,
+            IOS: 7,
+            STANDARDISED: 1
+        },
+        CONNECTION_TIMED_OUT: {
+            ANDROID: -118,
+            IOS: 57,
+            STANDARDISED: 2
+        }
+    },
     OS = platform.id == 'android' ? 'ANDROID' : 'IOS';
 
 exports.create = function(properties, callback) {
@@ -208,20 +208,20 @@ function registerReceiveEvents() {
         })();
     }
 
-	function standardiseErrorCode(errorCode) {
-		var errorCode;
-		
-		Object.keys(ERROR_CODES).forEach(function(type){
-			if (ERROR_CODES[type][OS] === errorCode) {
-				errorCode = ERROR_CODES[type].STANDARDISED
-			}
-		})
-		return errorCode;
-	}
-	
-    var fail = function(info) {
-		info.resultCode = standardiseErrorCode(info.resultCode)
-		
+    function standardiseErrorCode(errorCode) {
+        var errorCode;
+
+        Object.keys(ERROR_CODES).forEach(function (type) {
+            if (ERROR_CODES[type][OS] === errorCode) {
+                errorCode = ERROR_CODES[type].STANDARDISED
+            }
+        })
+        return errorCode;
+    }
+
+    var fail = function (info) {
+        info.resultCode = standardiseErrorCode(info.resultCode)
+
         exports.onReceiveError.fire(info);
     };
 

--- a/sockets.tcp.js
+++ b/sockets.tcp.js
@@ -16,7 +16,7 @@ var exec = cordova.require('cordova/exec'),
             STANDARDISED: 2
         }
     },
-    OS = platform.id == 'android' ? 'ANDROID' : 'IOS';
+    OS = platform.id === 'android' ? 'ANDROID' : 'IOS';
 
 exports.create = function(properties, callback) {
     if (typeof properties == 'function') {
@@ -208,7 +208,7 @@ function registerReceiveEvents() {
         })();
     }
 
-    function standardiseErrorCode(errorCode) {
+    function getStandardiseErrorCode(errorCode) {
         var matchedError = Object.keys(ERROR_CODES).find(function (type) {
                 return ERROR_CODES[type][OS] === errorCode;
             });
@@ -217,7 +217,7 @@ function registerReceiveEvents() {
     }
 
     var fail = function (info) {
-        info.resultCode = standardiseErrorCode(info.resultCode)
+        info.resultCode = getStandardiseErrorCode(info.resultCode);
 
         exports.onReceiveError.fire(info);
     };

--- a/sockets.tcp.js
+++ b/sockets.tcp.js
@@ -209,14 +209,14 @@ function registerReceiveEvents() {
     }
 
     function standardiseErrorCode(errorCode) {
-        var errorCode;
+        var standardErrorCode;
 
         Object.keys(ERROR_CODES).forEach(function (type) {
             if (ERROR_CODES[type][OS] === errorCode) {
-                errorCode = ERROR_CODES[type].STANDARDISED
+                standardErrorCode = ERROR_CODES[type].STANDARDISED
             }
         })
-        return errorCode;
+        return standardErrorCode;
     }
 
     var fail = function (info) {

--- a/sockets.tcp.js
+++ b/sockets.tcp.js
@@ -209,14 +209,12 @@ function registerReceiveEvents() {
     }
 
     function standardiseErrorCode(errorCode) {
-        var standardErrorCode;
+        var standardErrorCode,
+            matchedError = Object.keys(ERROR_CODES).find(function (type) {
+                return ERROR_CODES[type][OS] === errorCode;
+            });
 
-        Object.keys(ERROR_CODES).forEach(function (type) {
-            if (ERROR_CODES[type][OS] === errorCode) {
-                standardErrorCode = ERROR_CODES[type].STANDARDISED
-            }
-        })
-        return standardErrorCode;
+        return ERROR_CODES[matchedError].STANDARDISED;
     }
 
     var fail = function (info) {

--- a/sockets.tcp.js
+++ b/sockets.tcp.js
@@ -4,19 +4,19 @@
 var Event = require('cordova-plugin-chrome-apps-common.events');
 var platform = cordova.require('cordova/platform');
 var exec = cordova.require('cordova/exec'),
-	ANDROID_SOCKET_ERROR_CODES = {
-        	SOCKET_CLOSED_BY_SERVER: -100,
-        	CONNECTION_TIMED_OUT: -118
-    },
-    IOS_SOCKET_ERROR_CODES = {
-        	SOCKET_CLOSED_BY_SERVER: 7,
-        	CONNECTION_TIMED_OUT: 57
-    },
- 	STANDARDISED_ERROR_CODES = {
-        	SOCKET_CLOSED_BY_SERVER: 1,
-        	CONNECTION_TIMED_OUT: 2
-    },
-    NATIVE_ERROR_CODES = platform.id == 'android' ? ANDROID_SOCKET_ERROR_CODES : IOS_SOCKET_ERROR_CODES;
+	ERROR_CODES = {
+	  SOCKET_CLOSED_BY_SERVER: {
+	    ANDROID: -100,
+	    IOS: 7,
+	    STANDARDISED: 1
+	  },
+	  CONNECTION_TIMED_OUT: {
+	    ANDROID: -118,
+	    IOS: 57,
+	    STANDARDISED: 2
+	  }
+	},
+    OS = platform.id == 'android' ? ANDROID : IOS;
 
 exports.create = function(properties, callback) {
     if (typeof properties == 'function') {
@@ -209,11 +209,14 @@ function registerReceiveEvents() {
     }
 
 	function standardiseErrorCode(errorCode) {
-		var errorType = Object.keys(NATIVE_ERROR_CODES).find(function (type) {
-			return (NATIVE_ERROR_CODES[type] === info.resultCode);
-		});
+		var errorCode;
 		
-		return STANDARDISED_ERROR_CODES[errorType];
+		Object.keys(ERROR_CODES).forEach(function(type){
+			if (ERROR_CODES[type][OS] === errorCode) {
+				errorCode = ERROR_CODES[type].STANDARDISED
+			}
+		})
+		return errorCode;
 	}
 	
     var fail = function(info) {

--- a/sockets.tcp.js
+++ b/sockets.tcp.js
@@ -3,7 +3,16 @@
 // found in the LICENSE file.
 var Event = require('cordova-plugin-chrome-apps-common.events');
 var platform = cordova.require('cordova/platform');
-var exec = cordova.require('cordova/exec');
+var exec = cordova.require('cordova/exec'),
+	ANDROID_SOCKET_ERROR_CODES = {
+        	SOCKET_CLOSED_BY_SERVER: -100,
+        	CONNECTION_TIMED_OUT: -118
+    },
+    IOS_SOCKET_ERROR_CODES = {
+        	SOCKET_CLOSED_BY_SERVER: 7,
+        	CONNECTION_TIMED_OUT: 57
+    },
+    HANDLED_ERROR_CODES = platform.id == 'android' ? ANDROID_SOCKET_ERROR_CODES : IOS_SOCKET_ERROR_CODES;
 
 exports.create = function(properties, callback) {
     if (typeof properties == 'function') {
@@ -196,6 +205,7 @@ function registerReceiveEvents() {
     }
 
     var fail = function(info) {
+	debugger
         exports.onReceiveError.fire(info);
     };
 


### PR DESCRIPTION
Since both Android and iOS' native implementation of sockets return different error codes, I have added some code within the JS interface that standardises the error code before reporting back to our side