### PR TITLE
Fire callback when an error occurs during the send function

### DIFF
--- a/sockets.tcp.js
+++ b/sockets.tcp.js
@@ -119,7 +119,6 @@ exports.send = function(socketId, data, callback) {
             message: error.message,
             socketId: socketId
         };
-        callback(sendInfo);
         exports.onReceiveError.fire(sendInfo);
     };
     if (data.byteLength == 0) {

--- a/sockets.tcp.js
+++ b/sockets.tcp.js
@@ -117,6 +117,7 @@ exports.send = function(socketId, data, callback) {
             bytesSent: 0,
             resultCode: error.resultCode
         };
+         callback(sendInfo);
          exports.onReceiveError.fire(error, sendInfo);
     };
     if (data.byteLength == 0) {

--- a/sockets.tcp.js
+++ b/sockets.tcp.js
@@ -115,7 +115,8 @@ exports.send = function(socketId, data, callback) {
     var fail = callback && function(error) {
         var sendInfo = {
             bytesSent: 0,
-            resultCode: error.resultCode
+            resultCode: error.resultCode,
+            message: error.message
         };
          callback(sendInfo);
          exports.onReceiveError.fire(error, sendInfo);

--- a/sockets.tcp.js
+++ b/sockets.tcp.js
@@ -116,10 +116,11 @@ exports.send = function(socketId, data, callback) {
         var sendInfo = {
             bytesSent: 0,
             resultCode: error.resultCode,
-            message: error.message
+            message: error.message,
+            socketId: socketId
         };
-         callback(sendInfo);
-         exports.onReceiveError.fire(error, sendInfo);
+        callback(sendInfo);
+        exports.onReceiveError.fire(sendInfo);
     };
     if (data.byteLength == 0) {
       win(0);


### PR DESCRIPTION
Changes:
Initially thought callback needed to be fired, but turns out the data that was coming back from the error event was just incomplete.

Why:
So we don’t get an infinite loading spinner should the send function fail.