### PR TITLE
Returning additional error details as some catch's weren't working without the socket ID

### DIFF
--- a/sockets.tcp.js
+++ b/sockets.tcp.js
@@ -50,12 +50,8 @@ exports.setKeepAlive = function(socketId, enabled, delay, callback) {
             callback(0);
         };
         var fail = callback && function(error) {
-                var sendInfo = {
-                    bytesSent: 0,
-                    resultCode: error.resultCode,
-                    message: error.message,
-                    socketId: socketId
-                };
+                var sendInfo = createErrorObj(error, socketId);
+
                 exports.onReceiveError.fire(sendInfo);
         };
         exec(win, fail, 'ChromeSocketsTcp', 'setKeepAlive', [socketId, enabled, delay]);
@@ -70,12 +66,8 @@ exports.setNoDelay = function(socketId, noDelay, callback) {
             callback(0);
         };
         var fail = callback && function(error) {
-                var sendInfo = {
-                    bytesSent: 0,
-                    resultCode: error.resultCode,
-                    message: error.message,
-                    socketId: socketId
-                };
+                var sendInfo = createErrorObj(error, socketId);
+
                 exports.onReceiveError.fire(sendInfo);
         };
         exec(win, fail, 'ChromeSocketsTcp', 'setNoDelay', [socketId, noDelay]);
@@ -89,12 +81,8 @@ exports.connect = function(socketId, peerAddress, peerPort, callback) {
         callback(0);
     };
     var fail = callback && function(error) {
-            var sendInfo = {
-                bytesSent: 0,
-                resultCode: error.resultCode,
-                message: error.message,
-                socketId: socketId
-            };
+            var sendInfo = createErrorObj(error, socketId);
+
             exports.onReceiveError.fire(sendInfo);
     };
     exec(win, fail, 'ChromeSocketsTcp', 'connect', [socketId, peerAddress, peerPort]);
@@ -113,12 +101,8 @@ exports.secure = function(socketId, options, callback) {
         callback(0);
     };
     var fail = callback && function(error) {
-            var sendInfo = {
-                bytesSent: 0,
-                resultCode: error.resultCode,
-                message: error.message,
-                socketId: socketId
-            };
+            var sendInfo = createErrorObj(error, socketId);
+
             exports.onReceiveError.fire(sendInfo);
     };
     exec(win, fail, 'ChromeSocketsTcp', 'secure', [socketId, options]);
@@ -137,12 +121,8 @@ exports.send = function(socketId, data, callback) {
         callback(sendInfo);
     };
     var fail = callback && function(error) {
-        var sendInfo = {
-            bytesSent: 0,
-            resultCode: error.resultCode,
-            message: error.message,
-            socketId: socketId
-        };
+            var sendInfo = createErrorObj(error, socketId);
+
         exports.onReceiveError.fire(sendInfo);
     };
     if (data.byteLength == 0) {
@@ -182,6 +162,15 @@ exports.pipeToFile = function(socketId, options, callback) {
 
 exports.onReceive = new Event('onReceive');
 exports.onReceiveError = new Event('onReceiveError');
+
+function createErrorObj(error, socketId) {
+    return {
+        bytesSent: 0,
+        resultCode: error.resultCode,
+        message: error.message,
+        socketId: socketId
+    };
+}
 
 function registerReceiveEvents() {
 

--- a/sockets.tcp.js
+++ b/sockets.tcp.js
@@ -50,7 +50,13 @@ exports.setKeepAlive = function(socketId, enabled, delay, callback) {
             callback(0);
         };
         var fail = callback && function(error) {
-            exports.onReceiveError.fire(error);
+                var sendInfo = {
+                    bytesSent: 0,
+                    resultCode: error.resultCode,
+                    message: error.message,
+                    socketId: socketId
+                };
+                exports.onReceiveError.fire(sendInfo);
         };
         exec(win, fail, 'ChromeSocketsTcp', 'setKeepAlive', [socketId, enabled, delay]);
     } else {
@@ -64,7 +70,13 @@ exports.setNoDelay = function(socketId, noDelay, callback) {
             callback(0);
         };
         var fail = callback && function(error) {
-            exports.onReceiveError.fire(error);
+                var sendInfo = {
+                    bytesSent: 0,
+                    resultCode: error.resultCode,
+                    message: error.message,
+                    socketId: socketId
+                };
+                exports.onReceiveError.fire(sendInfo);
         };
         exec(win, fail, 'ChromeSocketsTcp', 'setNoDelay', [socketId, noDelay]);
     } else {
@@ -77,7 +89,13 @@ exports.connect = function(socketId, peerAddress, peerPort, callback) {
         callback(0);
     };
     var fail = callback && function(error) {
-        exports.onReceiveError.fire(error);
+            var sendInfo = {
+                bytesSent: 0,
+                resultCode: error.resultCode,
+                message: error.message,
+                socketId: socketId
+            };
+            exports.onReceiveError.fire(sendInfo);
     };
     exec(win, fail, 'ChromeSocketsTcp', 'connect', [socketId, peerAddress, peerPort]);
 };
@@ -95,7 +113,13 @@ exports.secure = function(socketId, options, callback) {
         callback(0);
     };
     var fail = callback && function(error) {
-        exports.onReceiveError.fire(error);
+            var sendInfo = {
+                bytesSent: 0,
+                resultCode: error.resultCode,
+                message: error.message,
+                socketId: socketId
+            };
+            exports.onReceiveError.fire(sendInfo);
     };
     exec(win, fail, 'ChromeSocketsTcp', 'secure', [socketId, options]);
 };


### PR DESCRIPTION
Returning additional error details as some catch’s weren’t catching due to the socket ID being missing from the error object.